### PR TITLE
Load collapsed folder tree by default

### DIFF
--- a/client/src/components/Dashboard.js
+++ b/client/src/components/Dashboard.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Card, Statistic, Row, Col, Spin, Alert } from 'antd';
+import { Card, Statistic, Row, Col, Spin, Alert, Table, Modal, Button, Tag, Space, Typography, Empty, message } from 'antd';
 import { 
   FolderOutlined, 
   FileOutlined, 
@@ -11,13 +11,28 @@ import { ApiService } from '../services/api';
 
 const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884d8', '#82ca9d'];
 
+const { Text, Paragraph } = Typography;
+
 const Dashboard = ({ refreshTrigger }) => {
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [rootPaths, setRootPaths] = useState([]);
+  const [rootPathsLoading, setRootPathsLoading] = useState(true);
+  const [rootPathsError, setRootPathsError] = useState(null);
+  const [detailsVisible, setDetailsVisible] = useState(false);
+  const [detailsLoading, setDetailsLoading] = useState(false);
+  const [detailsError, setDetailsError] = useState(null);
+  const [selectedRootPath, setSelectedRootPath] = useState(null);
+  const [rootPathHistory, setRootPathHistory] = useState([]);
+  const [rootPathTotals, setRootPathTotals] = useState(null);
+  const [rootPathCurrentData, setRootPathCurrentData] = useState(null);
+  const [deleteConfirmVisible, setDeleteConfirmVisible] = useState(false);
+  const [deletingRootPath, setDeletingRootPath] = useState(false);
 
   useEffect(() => {
     fetchStats();
+    fetchRootPaths();
   }, [refreshTrigger]);
 
   const fetchStats = async () => {
@@ -33,8 +48,22 @@ const Dashboard = ({ refreshTrigger }) => {
     }
   };
 
+  const fetchRootPaths = async () => {
+    setRootPathsLoading(true);
+    setRootPathsError(null);
+    try {
+      const data = await ApiService.getRootPaths();
+      setRootPaths(data.rootPaths || []);
+    } catch (err) {
+      setRootPathsError(err.message);
+      setRootPaths([]);
+    } finally {
+      setRootPathsLoading(false);
+    }
+  };
+
   const formatBytes = (bytes) => {
-    if (bytes === 0) return '0 Bytes';
+    if (!bytes) return '0 Bytes';
     const k = 1024;
     const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
     const i = Math.floor(Math.log(bytes) / Math.log(k));
@@ -45,6 +74,177 @@ const Dashboard = ({ refreshTrigger }) => {
     if (!dateString) return 'Never';
     return new Date(dateString).toLocaleString();
   };
+
+  const renderStatusTag = (status) => {
+    if (!status) {
+      return <Tag>UNKNOWN</Tag>;
+    }
+
+    const normalizedStatus = status.toLowerCase();
+    const colorMap = {
+      completed: 'green',
+      running: 'blue',
+      pending: 'gold',
+      failed: 'red',
+      error: 'red'
+    };
+
+    return <Tag color={colorMap[normalizedStatus] || 'default'}>{normalizedStatus.toUpperCase()}</Tag>;
+  };
+
+  const openRootPathDetails = async (record) => {
+    setSelectedRootPath(record);
+    setDetailsVisible(true);
+    setDetailsLoading(true);
+    setDetailsError(null);
+
+    try {
+      const data = await ApiService.getRootPathDetails(record.rootPath);
+      setRootPathHistory(data.scans || []);
+      setRootPathTotals(data.totals || null);
+      setRootPathCurrentData(data.currentData || null);
+    } catch (err) {
+      setDetailsError(err.message);
+      setRootPathHistory([]);
+      setRootPathTotals(null);
+      setRootPathCurrentData(null);
+    } finally {
+      setDetailsLoading(false);
+    }
+  };
+
+  const closeDetailsModal = () => {
+    setDetailsVisible(false);
+    setSelectedRootPath(null);
+    setRootPathHistory([]);
+    setRootPathTotals(null);
+    setRootPathCurrentData(null);
+    setDetailsError(null);
+  };
+
+  const handleDeleteRootPath = async () => {
+    if (!selectedRootPath) return;
+
+    const pathToDelete = selectedRootPath.rootPath;
+    setDeletingRootPath(true);
+
+    try {
+      await ApiService.deleteByPath(pathToDelete, 'both');
+      message.success(`Đã xóa dữ liệu cho ${pathToDelete}`);
+      setDeleteConfirmVisible(false);
+      closeDetailsModal();
+      setRootPaths((prev) => prev.filter((item) => item.rootPath !== pathToDelete));
+      fetchStats();
+      fetchRootPaths();
+    } catch (err) {
+      message.error(err.message || 'Không thể xóa đường dẫn này');
+    } finally {
+      setDeletingRootPath(false);
+    }
+  };
+
+  const renderScanOptions = (options) => {
+    if (!options || (typeof options === 'object' && Object.keys(options).length === 0)) {
+      return '-';
+    }
+
+    const content = typeof options === 'string' ? options : JSON.stringify(options);
+    return <Text code style={{ whiteSpace: 'pre-wrap' }}>{content}</Text>;
+  };
+
+  const rootPathColumns = [
+    {
+      title: 'Đường dẫn gốc',
+      dataIndex: 'rootPath',
+      key: 'rootPath',
+      ellipsis: true,
+      render: (value) => <Text strong>{value}</Text>
+    },
+    {
+      title: 'Ngày quét gần nhất',
+      dataIndex: 'createdAt',
+      key: 'createdAt',
+      render: (value) => formatDate(value)
+    },
+    {
+      title: 'Hoàn thành',
+      dataIndex: 'completedAt',
+      key: 'completedAt',
+      render: (value) => formatDate(value)
+    },
+    {
+      title: 'Thư mục',
+      dataIndex: 'foldersCount',
+      key: 'foldersCount',
+      align: 'right'
+    },
+    {
+      title: 'Tệp',
+      dataIndex: 'filesCount',
+      key: 'filesCount',
+      align: 'right'
+    },
+    {
+      title: 'Số lần quét',
+      dataIndex: 'scanCount',
+      key: 'scanCount',
+      align: 'right'
+    },
+    {
+      title: 'Trạng thái',
+      dataIndex: 'status',
+      key: 'status',
+      render: (status) => renderStatusTag(status)
+    },
+    {
+      title: 'Thao tác',
+      key: 'actions',
+      render: (_, record) => (
+        <Button type="link" onClick={() => openRootPathDetails(record)}>
+          Xem chi tiết
+        </Button>
+      )
+    }
+  ];
+
+  const historyColumns = [
+    {
+      title: 'Thời gian bắt đầu',
+      dataIndex: 'createdAt',
+      key: 'createdAt',
+      render: (value) => formatDate(value)
+    },
+    {
+      title: 'Hoàn thành',
+      dataIndex: 'completedAt',
+      key: 'completedAt',
+      render: (value) => formatDate(value)
+    },
+    {
+      title: 'Trạng thái',
+      dataIndex: 'status',
+      key: 'status',
+      render: (status) => renderStatusTag(status)
+    },
+    {
+      title: 'Thư mục',
+      dataIndex: 'foldersCount',
+      key: 'foldersCount',
+      align: 'right'
+    },
+    {
+      title: 'Tệp',
+      dataIndex: 'filesCount',
+      key: 'filesCount',
+      align: 'right'
+    },
+    {
+      title: 'Tùy chọn',
+      dataIndex: 'scanOptions',
+      key: 'scanOptions',
+      render: (value) => renderScanOptions(value)
+    }
+  ];
 
   if (loading) {
     return (
@@ -258,6 +458,156 @@ const Dashboard = ({ refreshTrigger }) => {
           </Card>
         </Col>
       </Row>
+
+      <Card title="Danh sách đường dẫn đã quét" style={{ marginTop: 24 }}>
+        {rootPathsLoading ? (
+          <div style={{ textAlign: 'center', padding: '40px 0' }}>
+            <Spin size="large" />
+          </div>
+        ) : rootPathsError ? (
+          <Alert
+            type="error"
+            message="Không thể tải danh sách đường dẫn"
+            description={rootPathsError}
+            showIcon
+            action={
+              <Button type="link" onClick={fetchRootPaths}>
+                Thử lại
+              </Button>
+            }
+          />
+        ) : rootPaths.length === 0 ? (
+          <Empty description="Chưa có đường dẫn nào được quét" />
+        ) : (
+          <Table
+            dataSource={rootPaths}
+            columns={rootPathColumns}
+            rowKey={(record) => record.rootPath}
+            pagination={{ pageSize: 5, hideOnSinglePage: true }}
+          />
+        )}
+      </Card>
+
+      <Modal
+        open={detailsVisible}
+        onCancel={closeDetailsModal}
+        title={selectedRootPath ? `Chi tiết quét: ${selectedRootPath.rootPath}` : 'Chi tiết quét'}
+        width={900}
+        footer={[
+          <Button key="cancel" onClick={closeDetailsModal}>
+            Đóng
+          </Button>,
+          <Button
+            key="delete"
+            danger
+            onClick={() => setDeleteConfirmVisible(true)}
+            disabled={!selectedRootPath}
+          >
+            Xóa đường dẫn
+          </Button>
+        ]}
+      >
+        {detailsLoading ? (
+          <div style={{ textAlign: 'center', padding: '40px 0' }}>
+            <Spin size="large" />
+          </div>
+        ) : detailsError ? (
+          <Alert
+            type="error"
+            message="Không thể tải chi tiết"
+            description={detailsError}
+            showIcon
+            action={
+              <Button type="link" onClick={() => selectedRootPath && openRootPathDetails(selectedRootPath)}>
+                Thử lại
+              </Button>
+            }
+          />
+        ) : (
+          <Space direction="vertical" size="large" style={{ width: '100%' }}>
+            <Row gutter={16}>
+              <Col span={6}>
+                <Statistic title="Tổng số lần quét" value={rootPathTotals?.scanCount || 0} />
+              </Col>
+              <Col span={6}>
+                <Statistic title="Thư mục đang lưu" value={rootPathCurrentData?.folderCount || 0} />
+              </Col>
+              <Col span={6}>
+                <Statistic title="Tệp đang lưu" value={rootPathCurrentData?.fileCount || 0} />
+              </Col>
+              <Col span={6}>
+                <Statistic title="Dung lượng hiện tại" value={formatBytes(rootPathCurrentData?.totalSize || 0)} />
+              </Col>
+            </Row>
+            <Row gutter={16}>
+              <Col span={12}>
+                <Statistic title="Lần quét gần nhất" value={formatDate(rootPathTotals?.latestScan)} />
+              </Col>
+              <Col span={12}>
+                <Statistic title="Hoàn thành" value={formatDate(rootPathTotals?.latestCompletion)} />
+              </Col>
+            </Row>
+            {rootPathHistory.length > 0 ? (
+              <Table
+                dataSource={rootPathHistory}
+                columns={historyColumns}
+                rowKey={(record) => record.id}
+                size="small"
+                pagination={{ pageSize: 6, hideOnSinglePage: true }}
+              />
+            ) : (
+              <Empty description="Chưa có lịch sử quét" />
+            )}
+          </Space>
+        )}
+      </Modal>
+
+      <Modal
+        open={deleteConfirmVisible}
+        title="Xóa dữ liệu"
+        onCancel={() => setDeleteConfirmVisible(false)}
+        onOk={handleDeleteRootPath}
+        okText="Xóa dữ liệu"
+        okButtonProps={{ danger: true, loading: deletingRootPath }}
+      >
+        <Alert
+          type="error"
+          showIcon
+          message="Cảnh báo"
+          description="Hành động này sẽ xóa vĩnh viễn dữ liệu khỏi database. Không thể hoàn tác!"
+        />
+        <Space direction="vertical" size="middle" style={{ width: '100%', marginTop: 16 }}>
+          <div>
+            <Text strong>Đường dẫn gốc cần xóa:</Text>
+            <Paragraph
+              style={{ marginBottom: 0 }}
+              copyable={selectedRootPath ? { text: selectedRootPath.rootPath } : undefined}
+            >
+              {selectedRootPath?.rootPath}
+            </Paragraph>
+          </div>
+          <div>
+            <Text strong>Loại xóa:</Text>
+            <Paragraph style={{ marginBottom: 0 }}>Xóa thư mục và file liên quan</Paragraph>
+          </div>
+          <div>
+            <Text strong>Thư mục hiện có:</Text> <Text>{rootPathCurrentData?.folderCount || 0}</Text>
+            <br />
+            <Text strong>Tệp hiện có:</Text> <Text>{rootPathCurrentData?.fileCount || 0}</Text>
+            <br />
+            <Text strong>Dung lượng lưu trữ:</Text> <Text>{formatBytes(rootPathCurrentData?.totalSize || 0)}</Text>
+          </div>
+          <Paragraph>
+            <Text strong>Ví dụ:</Text>
+            <br />
+            <Text code>E:\\New folder (4)</Text> - Xóa tất cả dữ liệu đường dẫn này
+            <br />
+            <Text code>D:\\Media\\Music</Text> - Xóa toàn bộ các folder/file nhạc
+            <br />
+            <Text code>C:\\Users\\Documents</Text> - Xóa dữ liệu thư mục tài liệu
+          </Paragraph>
+        </Space>
+      </Modal>
     </div>
   );
 };

--- a/client/src/components/VirtualFolderTree.js
+++ b/client/src/components/VirtualFolderTree.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { Card, Button, Typography, Modal, Space, message, Input } from 'antd';
+import { Card, Button, Typography, Modal, Space, message, Input, Spin } from 'antd';
 import { 
   FolderOutlined, 
   FolderOpenOutlined,
@@ -121,6 +121,10 @@ const VirtualFolderTree = ({ searchResults, refreshTrigger }) => {
   const [highlightPaths, setHighlightPaths] = useState(new Set());
   const [anchorPaths, setAnchorPaths] = useState(new Set());
   const [showAllFromPaths, setShowAllFromPaths] = useState(new Set());
+  const [initialRootFolders, setInitialRootFolders] = useState([]);
+  const [initialLoading, setInitialLoading] = useState(false);
+
+  const isSearchMode = !!searchResults;
 
   // Hard reset tree state when search results change (clear or new search)
   useEffect(() => {
@@ -131,9 +135,9 @@ const VirtualFolderTree = ({ searchResults, refreshTrigger }) => {
     setSelectedFolder(null);
     setModalVisible(false);
     setSearchTerm('');
-  setHighlightPaths(new Set());
-  setAnchorPaths(new Set());
-  setShowAllFromPaths(new Set());
+    setHighlightPaths(new Set());
+    setAnchorPaths(new Set());
+    setShowAllFromPaths(new Set());
     // Note: expandPaths and helpers will be applied by the effect below if present
   }, [searchResults]);
 
@@ -143,15 +147,16 @@ const VirtualFolderTree = ({ searchResults, refreshTrigger }) => {
     const toExpand = new Set(expandedPaths);
     searchResults.expandPaths.forEach(p => toExpand.add(p));
     setExpandedPaths(toExpand);
-  // New multi-value helpers
-  if (Array.isArray(searchResults.highlightPaths)) setHighlightPaths(new Set(searchResults.highlightPaths));
-  else if (searchResults.highlightPath) setHighlightPaths(new Set([searchResults.highlightPath]));
 
-  if (Array.isArray(searchResults.anchorPaths)) setAnchorPaths(new Set(searchResults.anchorPaths));
-  else if (searchResults.anchorPath) setAnchorPaths(new Set([searchResults.anchorPath]));
+    // New multi-value helpers
+    if (Array.isArray(searchResults.highlightPaths)) setHighlightPaths(new Set(searchResults.highlightPaths));
+    else if (searchResults.highlightPath) setHighlightPaths(new Set([searchResults.highlightPath]));
 
-  if (Array.isArray(searchResults.showAllFromPaths)) setShowAllFromPaths(new Set(searchResults.showAllFromPaths));
-  else if (searchResults.showAllFromPath) setShowAllFromPaths(new Set([searchResults.showAllFromPath]));
+    if (Array.isArray(searchResults.anchorPaths)) setAnchorPaths(new Set(searchResults.anchorPaths));
+    else if (searchResults.anchorPath) setAnchorPaths(new Set([searchResults.anchorPath]));
+
+    if (Array.isArray(searchResults.showAllFromPaths)) setShowAllFromPaths(new Set(searchResults.showAllFromPaths));
+    else if (searchResults.showAllFromPath) setShowAllFromPaths(new Set([searchResults.showAllFromPath]));
 
     // Preload children for each path in the chain to make them visible
     (async () => {
@@ -164,23 +169,67 @@ const VirtualFolderTree = ({ searchResults, refreshTrigger }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchResults?.expandPaths]);
 
+  // Load top-level folders for the default collapsed tree when there are no search results
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchRootFolders = async () => {
+      setInitialLoading(true);
+      try {
+        const response = await ApiService.getRootFolders();
+        if (!isMounted) return;
+
+        const folders = Array.isArray(response?.folders)
+          ? response.folders.map(folder => ({
+              ...folder,
+              hasChildren: typeof folder.hasChildren === 'boolean'
+                ? folder.hasChildren
+                : (folder.child_count || 0) > 0
+            }))
+          : [];
+
+        setInitialRootFolders(folders);
+      } catch (error) {
+        if (isMounted) {
+          setInitialRootFolders([]);
+          message.error('Failed to load folder tree');
+        }
+      } finally {
+        if (isMounted) {
+          setInitialLoading(false);
+        }
+      }
+    };
+
+    fetchRootFolders();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [refreshTrigger]);
+
   // Extract root folders (level 0 or folders without parents in current search)
   const rootFolders = useMemo(() => {
-    if (!searchResults?.folders) return [];
-    // If anchorPaths present, show only those nodes at the top (support multiple branches)
-    if (anchorPaths && anchorPaths.size > 0) {
-      const anchors = searchResults.folders.filter(f => anchorPaths.has(f.path));
-      return anchors.sort((a, b) => a.name.localeCompare(b.name));
+    if (isSearchMode && Array.isArray(searchResults?.folders)) {
+      // If anchorPaths present, show only those nodes at the top (support multiple branches)
+      if (anchorPaths && anchorPaths.size > 0) {
+        const anchors = searchResults.folders.filter(f => anchorPaths.has(f.path));
+        return anchors.sort((a, b) => a.name.localeCompare(b.name));
+      }
+
+      const folders = searchResults.folders;
+      const pathSet = new Set(folders.map(f => f.path));
+
+      return folders
+        .filter(folder => {
+          // Root if level is 0 OR parent is not in current search results
+          return folder.level === 0 || !pathSet.has(folder.parent_path);
+        })
+        .sort((a, b) => a.name.localeCompare(b.name));
     }
 
-    const folders = searchResults.folders;
-    const pathSet = new Set(folders.map(f => f.path));
-    
-    return folders.filter(folder => {
-      // Root if level is 0 OR parent is not in current search results
-      return folder.level === 0 || !pathSet.has(folder.parent_path);
-    }).sort((a, b) => a.name.localeCompare(b.name));
-  }, [searchResults, anchorPaths]);
+    return initialRootFolders;
+  }, [searchResults, anchorPaths, initialRootFolders, isSearchMode]);
 
   // Filter folders based on search term
   useEffect(() => {
@@ -274,7 +323,7 @@ const VirtualFolderTree = ({ searchResults, refreshTrigger }) => {
     // (This could be enhanced with a backend API that returns child counts)
     folder.hasChildren = hasChildren || folder.level < 10; // Assume folders can have children
 
-  const isHighlight = highlightPaths.has(path);
+    const isHighlight = highlightPaths.has(path);
 
     // If this node is the anchor, restrict visible children to the single branch child
     if (anchorPaths.size > 0 && showAllFromPaths.size > 0 && anchorPaths.has(path) && children.length > 0) {
@@ -282,18 +331,18 @@ const VirtualFolderTree = ({ searchResults, refreshTrigger }) => {
       children = children.filter(ch => showAllFromPaths.has(ch.path) || highlightPaths.has(ch.path));
     }
 
-  return (
-    <TreeNode
+    return (
+      <TreeNode
         key={path}
         node={folder}
         level={level}
         isExpanded={isExpanded}
         onToggle={handleToggle}
         onSelect={handleSelect}
-    isLoading={isLoading}
-    isHighlight={isHighlight}
+        isLoading={isLoading}
+        isHighlight={isHighlight}
         children={
-          isExpanded && children.length > 0 
+          isExpanded && children.length > 0
             ? children.map(child => renderNode(child, level + 1))
             : null
         }
@@ -367,19 +416,9 @@ const VirtualFolderTree = ({ searchResults, refreshTrigger }) => {
     });
   };
 
-  if (!searchResults) {
-    return (
-      <Card>
-        <div style={{ textAlign: 'center', padding: '50px' }}>
-          <Text type="secondary">No folder data available. Run a folder scan to populate the database.</Text>
-        </div>
-      </Card>
-    );
-  }
-
   return (
     <div>
-      <Card 
+      <Card
         title={`Virtual Folder Tree (${searchResults?.totalFolders || filteredNodes.length} folders)`}
         extra={
           <Space>
@@ -419,20 +458,31 @@ const VirtualFolderTree = ({ searchResults, refreshTrigger }) => {
           </Space>
         }
       >
-        <div style={{ 
-          maxHeight: '70vh', 
+        <div style={{
+          maxHeight: '70vh',
           overflowY: 'auto',
           border: '1px solid #f0f0f0',
           borderRadius: '6px',
           backgroundColor: '#fafafa'
         }}>
-          {filteredNodes.length > 0 ? (
+          {initialLoading && !isSearchMode ? (
+            <div style={{ textAlign: 'center', padding: '50px' }}>
+              <Spin indicator={<LoadingOutlined spin />} />
+              <div style={{ marginTop: 12 }}>
+                <Text type="secondary">Loading folder tree...</Text>
+              </div>
+            </div>
+          ) : filteredNodes.length > 0 ? (
             <div style={{ padding: '8px' }}>
               {filteredNodes.map(folder => renderNode(folder, 0))}
             </div>
           ) : (
             <div style={{ textAlign: 'center', padding: '50px', color: '#999' }}>
-              {searchTerm ? 'No folders found matching your filter.' : 'No folders found.'}
+              {searchTerm
+                ? 'No folders found matching your filter.'
+                : isSearchMode
+                  ? 'No folders found.'
+                  : 'No folder data available. Run a folder scan to populate the database.'}
             </div>
           )}
         </div>

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -47,6 +47,10 @@ export class ApiService {
     return this.request(`/search/children/${encodedPath}`);
   }
 
+  static async getRootFolders() {
+    return this.request('/search/folders/root');
+  }
+
   static async search(params) {
     const queryString = new URLSearchParams(params).toString();
     return this.request(`/search?${queryString}`);

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -65,6 +65,15 @@ export class ApiService {
     return this.request('/stats');
   }
 
+  static async getRootPaths() {
+    return this.request('/stats/root-paths');
+  }
+
+  static async getRootPathDetails(rootPath) {
+    const encodedPath = encodeURIComponent(rootPath);
+    return this.request(`/stats/root-paths/${encodedPath}`);
+  }
+
   static async getPathStats(path) {
     const queryString = new URLSearchParams({ path }).toString();
     return this.request(`/stats/path?${queryString}`);

--- a/server/routes/delete.js
+++ b/server/routes/delete.js
@@ -81,6 +81,7 @@ router.delete('/', (req, res) => {
     
     let deletedFolders = 0;
     let deletedFiles = 0;
+    let deletedScans = 0;
 
     // Validate deleteType
     if (!['folders', 'files', 'both'].includes(deleteType)) {
@@ -166,16 +167,48 @@ router.delete('/', (req, res) => {
         }));
       }
 
+      // Always delete scan history for this root path
+      promises.push(new Promise((resolve, reject) => {
+        db.get(
+          'SELECT COUNT(*) as count FROM scans WHERE user_id = ? AND root_path = ?',
+          [userId, rootPath],
+          (scanCountErr, scanCountResult) => {
+            if (scanCountErr) {
+              console.error('Error counting scans:', scanCountErr);
+              reject(scanCountErr);
+              return;
+            }
+
+            const scanCount = scanCountResult?.count || 0;
+
+            db.run(
+              'DELETE FROM scans WHERE user_id = ? AND root_path = ?',
+              [userId, rootPath],
+              function(scanDeleteErr) {
+                if (scanDeleteErr) {
+                  console.error('Error deleting scans:', scanDeleteErr);
+                  reject(scanDeleteErr);
+                } else {
+                  deletedScans = scanCount;
+                  resolve();
+                }
+              }
+            );
+          }
+        );
+      }));
+
       // Execute all deletions
       Promise.all(promises)
         .then(() => {
           console.log(`Delete operation completed. Folders: ${deletedFolders}, Files: ${deletedFiles}`);
-          
+
           res.json({
             success: true,
             message: `Delete operation completed`,
             deletedFolders,
             deletedFiles,
+            deletedScans,
             rootPath,
             deleteType
           });

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -11,12 +11,34 @@ router.get('/children/:encodedPath', (req, res) => {
     const parentPath = decodeURIComponent(req.params.encodedPath);
     
     db.all(`
-      SELECT id, path, name, parent_path, level, created_at, modified_at, accessed_at, scanned_at,
-             (SELECT COUNT(*) FROM folders f2 WHERE f2.user_id = ? AND f2.parent_path = folders.path) as child_count
-      FROM folders 
-      WHERE user_id = ? AND parent_path = ?
-      ORDER BY name
-    `, [userId, userId, parentPath], (err, children) => {
+      SELECT
+        folders.id,
+        folders.path,
+        folders.name,
+        folders.parent_path,
+        folders.level,
+        folders.created_at,
+        folders.modified_at,
+        folders.accessed_at,
+        folders.scanned_at,
+        COUNT(child.id) AS child_count
+      FROM folders
+      LEFT JOIN folders AS child
+        ON child.user_id = folders.user_id
+        AND child.parent_path = folders.path
+      WHERE folders.user_id = ? AND folders.parent_path = ?
+      GROUP BY
+        folders.id,
+        folders.path,
+        folders.name,
+        folders.parent_path,
+        folders.level,
+        folders.created_at,
+        folders.modified_at,
+        folders.accessed_at,
+        folders.scanned_at
+      ORDER BY folders.name
+    `, [userId, parentPath], (err, children) => {
       if (err) {
         console.error('Error fetching children:', err);
         return res.status(500).json({ error: 'Failed to fetch children' });
@@ -47,12 +69,35 @@ router.get('/folders/root', (req, res) => {
 
   try {
     db.all(`
-      SELECT id, path, name, parent_path, level, created_at, modified_at, accessed_at, scanned_at,
-             (SELECT COUNT(*) FROM folders f2 WHERE f2.user_id = ? AND f2.parent_path = folders.path) as child_count
+      SELECT
+        folders.id,
+        folders.path,
+        folders.name,
+        folders.parent_path,
+        folders.level,
+        folders.created_at,
+        folders.modified_at,
+        folders.accessed_at,
+        folders.scanned_at,
+        COUNT(child.id) AS child_count
       FROM folders
-      WHERE user_id = ? AND (level = 0 OR parent_path IS NULL OR parent_path = '')
-      ORDER BY name
-    `, [userId, userId], (err, rows) => {
+      LEFT JOIN folders AS child
+        ON child.user_id = folders.user_id
+        AND child.parent_path = folders.path
+      WHERE folders.user_id = ?
+        AND (folders.level = 0 OR folders.parent_path IS NULL OR folders.parent_path = '')
+      GROUP BY
+        folders.id,
+        folders.path,
+        folders.name,
+        folders.parent_path,
+        folders.level,
+        folders.created_at,
+        folders.modified_at,
+        folders.accessed_at,
+        folders.scanned_at
+      ORDER BY folders.name
+    `, [userId], (err, rows) => {
       if (err) {
         console.error('Error fetching root folders:', err);
         return res.status(500).json({ error: 'Failed to fetch root folders' });

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -6,7 +6,7 @@ const router = express.Router();
 router.get('/children/:encodedPath', (req, res) => {
   const db = req.app.locals.db;
   const userId = req.userId;
-  
+
   try {
     const parentPath = decodeURIComponent(req.params.encodedPath);
     
@@ -37,6 +37,40 @@ router.get('/children/:encodedPath', (req, res) => {
   } catch (error) {
     console.error('Children fetch error:', error);
     res.status(500).json({ error: 'Failed to fetch children', details: error.message });
+  }
+});
+
+// Get top-level folders for initial tree rendering
+router.get('/folders/root', (req, res) => {
+  const db = req.app.locals.db;
+  const userId = req.userId;
+
+  try {
+    db.all(`
+      SELECT id, path, name, parent_path, level, created_at, modified_at, accessed_at, scanned_at,
+             (SELECT COUNT(*) FROM folders f2 WHERE f2.user_id = ? AND f2.parent_path = folders.path) as child_count
+      FROM folders
+      WHERE user_id = ? AND (level = 0 OR parent_path IS NULL OR parent_path = '')
+      ORDER BY name
+    `, [userId, userId], (err, rows) => {
+      if (err) {
+        console.error('Error fetching root folders:', err);
+        return res.status(500).json({ error: 'Failed to fetch root folders' });
+      }
+
+      const folders = (rows || []).map(folder => ({
+        ...folder,
+        hasChildren: folder.child_count > 0
+      }));
+
+      res.json({
+        success: true,
+        folders
+      });
+    });
+  } catch (error) {
+    console.error('Root folders fetch error:', error);
+    res.status(500).json({ error: 'Failed to fetch root folders', details: error.message });
   }
 });
 

--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -208,6 +208,173 @@ router.get('/', (req, res) => {
   }
 });
 
+// Get latest scan information for each root path
+router.get('/root-paths', (req, res) => {
+  const db = req.app.locals.db;
+  const userId = req.userId;
+
+  try {
+    const query = `
+      SELECT
+        s.id,
+        s.root_path,
+        s.status,
+        s.folders_count,
+        s.files_count,
+        s.created_at,
+        s.completed_at,
+        (
+          SELECT COUNT(*)
+          FROM scans
+          WHERE user_id = s.user_id AND root_path = s.root_path
+        ) AS scan_count
+      FROM scans s
+      WHERE s.user_id = ?
+        AND NOT EXISTS (
+          SELECT 1
+          FROM scans newer
+          WHERE newer.user_id = s.user_id
+            AND newer.root_path = s.root_path
+            AND (
+              newer.created_at > s.created_at OR
+              (newer.created_at = s.created_at AND newer.id > s.id)
+            )
+        )
+      ORDER BY s.created_at DESC, s.id DESC
+    `;
+
+    db.all(query, [userId], (err, rows) => {
+      if (err) {
+        console.error('Root paths query failed:', err);
+        return res.status(500).json({ error: 'Could not get root paths' });
+      }
+
+      const rootPaths = (rows || []).map((row) => ({
+        id: row.id,
+        rootPath: row.root_path,
+        status: row.status,
+        foldersCount: row.folders_count,
+        filesCount: row.files_count,
+        createdAt: row.created_at,
+        completedAt: row.completed_at,
+        scanCount: row.scan_count
+      }));
+
+      res.json({ rootPaths });
+    });
+  } catch (error) {
+    console.error('Root paths error:', error);
+    res.status(500).json({ error: 'Could not get root paths', details: error.message });
+  }
+});
+
+// Get detailed scan history for a specific root path
+router.get('/root-paths/:encodedRootPath', (req, res) => {
+  const db = req.app.locals.db;
+  const userId = req.userId;
+
+  try {
+    const rootPath = decodeURIComponent(req.params.encodedRootPath || '');
+
+    if (!rootPath) {
+      return res.status(400).json({ error: 'Root path parameter is required' });
+    }
+
+    const historyQuery = `
+      SELECT
+        id,
+        status,
+        folders_count,
+        files_count,
+        created_at,
+        completed_at,
+        scan_options
+      FROM scans
+      WHERE user_id = ? AND root_path = ?
+      ORDER BY created_at DESC, id DESC
+    `;
+
+    db.all(historyQuery, [userId, rootPath], (err, rows) => {
+      if (err) {
+        console.error('Root path history failed:', err);
+        return res.status(500).json({ error: 'Could not get root path history' });
+      }
+
+      const scans = (rows || []).map((row) => {
+        let scanOptions = null;
+        if (row.scan_options) {
+          try {
+            scanOptions = JSON.parse(row.scan_options);
+          } catch (parseError) {
+            scanOptions = row.scan_options;
+          }
+        }
+
+        return {
+          id: row.id,
+          status: row.status,
+          foldersCount: row.folders_count,
+          filesCount: row.files_count,
+          createdAt: row.created_at,
+          completedAt: row.completed_at,
+          scanOptions
+        };
+      });
+
+      db.get(
+        `
+          SELECT COUNT(*) as folderCount
+          FROM folders
+          WHERE user_id = ? AND path LIKE ?
+        `,
+        [userId, `${rootPath}%`],
+        (folderErr, folderStats) => {
+          if (folderErr) {
+            console.error('Folder stats failed:', folderErr);
+            return res.status(500).json({ error: 'Could not get folder statistics' });
+          }
+
+          db.get(
+            `
+              SELECT
+                COUNT(*) as fileCount,
+                SUM(f.size) as totalSize
+              FROM files f
+              LEFT JOIN folders ON f.folder_id = folders.id
+              WHERE folders.user_id = ? AND folders.path LIKE ?
+            `,
+            [userId, `${rootPath}%`],
+            (fileErr, fileStats) => {
+              if (fileErr) {
+                console.error('File stats failed:', fileErr);
+                return res.status(500).json({ error: 'Could not get file statistics' });
+              }
+
+              res.json({
+                rootPath,
+                scans,
+                totals: {
+                  scanCount: scans.length,
+                  latestScan: scans[0]?.createdAt || null,
+                  latestCompletion: scans[0]?.completedAt || null
+                },
+                currentData: {
+                  folderCount: folderStats?.folderCount || 0,
+                  fileCount: fileStats?.fileCount || 0,
+                  totalSize: fileStats?.totalSize || 0
+                }
+              });
+            }
+          );
+        }
+      );
+    });
+  } catch (error) {
+    console.error('Root path detail error:', error);
+    res.status(500).json({ error: 'Could not get root path detail', details: error.message });
+  }
+});
+
 // Get detailed statistics for a specific path
 router.get('/path', (req, res) => {
   const db = req.app.locals.db;


### PR DESCRIPTION
## Summary
- add a backend endpoint to fetch top-level folders so folder mode can load the tree without a search
- fetch and render the root folders on the client, keeping the tree collapsed while showing a loading spinner for the initial load
- expose a client API helper for the new endpoint while preserving the existing search-driven behaviour

## Testing
- npm test -- --watchAll=false *(fails: react-scripts not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1503620188332b4e792c486b92a72