### PR TITLE
Add configurable search result limit

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -44,13 +44,24 @@ const MainApp = () => {
   const handleSearch = async (searchParams) => {
     setLoadingData(true);
     try {
+      const limitEnabled = searchParams.limitEnabled !== false && searchParams.limitEnabled !== 'false';
+      const parsedLimit = Number(searchParams.limit);
+      const normalizedLimit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : 100;
+
       // Add default pagination if not provided
       const searchWithPagination = {
         ...searchParams,
-        page: searchParams.page || 1,
-        limit: searchParams.limit || 100
+        page: searchParams.page || 1
       };
-      
+
+      if (limitEnabled) {
+        searchWithPagination.limit = normalizedLimit;
+        searchWithPagination.limitEnabled = true;
+      } else {
+        delete searchWithPagination.limit;
+        searchWithPagination.limitEnabled = false;
+      }
+
       const results = await ApiService.search(searchWithPagination);
       setSearchResults({ ...results, isNewSearch: true });
       setCurrentSearchParams(searchWithPagination);
@@ -64,7 +75,12 @@ const MainApp = () => {
 
   const handlePageChange = async (paginationParams) => {
     if (!currentSearchParams) return;
-    
+
+    const limitEnabled = currentSearchParams.limitEnabled !== false && currentSearchParams.limitEnabled !== 'false';
+    if (!limitEnabled) {
+      return;
+    }
+
     setLoadingData(true);
     try {
       const searchWithNewPagination = {

--- a/client/src/components/FileMode.js
+++ b/client/src/components/FileMode.js
@@ -179,9 +179,9 @@ const FileMode = ({ searchResults, refreshTrigger, onPageChange }) => {
       pageSize: paginationConfig.pageSize,
     };
     setPagination(newPagination);
-    
+
     // Call parent callback to refetch data with new pagination
-    if (onPageChange) {
+    if (onPageChange && searchResults?.pagination?.limitEnabled !== false) {
       onPageChange({
         page: paginationConfig.current,
         limit: paginationConfig.pageSize
@@ -196,6 +196,9 @@ const FileMode = ({ searchResults, refreshTrigger, onPageChange }) => {
       setPagination(prev => ({
         ...prev,
         total: backendTotal,
+        pageSize: searchResults.pagination?.limitEnabled === false
+          ? prev.pageSize
+          : (searchResults.pagination?.limit || prev.pageSize),
         // Reset to page 1 only if it's a new search (not pagination)
         current: searchResults.isNewSearch ? 1 : prev.current
       }));
@@ -250,11 +253,13 @@ const FileMode = ({ searchResults, refreshTrigger, onPageChange }) => {
             scroll={{ x: 1200 }}
             size="small"
           />
-          
+
           {searchResults.pagination && (
             <div style={{ marginTop: 16, textAlign: 'center' }}>
               <Text type="secondary">
-                Showing page {searchResults.pagination.page} of {searchResults.pagination.totalPages}
+                {searchResults.pagination.limitEnabled === false
+                  ? 'Showing all results (no limit applied)'
+                  : `Showing page ${searchResults.pagination.page} of ${searchResults.pagination.totalPages}`}
               </Text>
             </div>
           )}

--- a/client/src/components/SearchPanel.js
+++ b/client/src/components/SearchPanel.js
@@ -12,7 +12,8 @@ import {
   DatePicker,
   Modal,
   Space,
-  message
+  message,
+  Checkbox
 } from 'antd';
 import {
   SearchOutlined,
@@ -48,9 +49,11 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
     caseSensitive: false,
     extension: '',
     sizeRange: undefined,
-  dateRange: undefined,
-  ancestorLevels: 0,
-  ancestorMode: 'from-root'
+    dateRange: undefined,
+    ancestorLevels: 0,
+    ancestorMode: 'from-root',
+    limitEnabled: true,
+    limit: 100
   });
   
   // Create form instances - warnings will be suppressed by destroyOnClose
@@ -149,6 +152,10 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
       }
       const searchValues = await searchForm.validateFields(['query']);
       
+      const limitEnabled = searchSettings.limitEnabled !== false;
+      const limitValueRaw = Number(searchSettings.limit);
+      const limitValue = Number.isFinite(limitValueRaw) && limitValueRaw > 0 ? limitValueRaw : 100;
+
       const searchParams = {
         query: searchValues.query || '',
         mode: searchSettings.mode || 'contains',
@@ -160,10 +167,11 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
         sizeMax: searchSettings.sizeRange?.[1] || '',
         dateFrom: searchSettings.dateRange?.[0]?.format('YYYY-MM-DD') || '',
         dateTo: searchSettings.dateRange?.[1]?.format('YYYY-MM-DD') || '',
-  ancestorLevels: Number.isFinite(Number(searchSettings.ancestorLevels)) ? Number(searchSettings.ancestorLevels) : 0,
-  ancestorMode: searchSettings.ancestorMode || 'from-root',
+        ancestorLevels: Number.isFinite(Number(searchSettings.ancestorLevels)) ? Number(searchSettings.ancestorLevels) : 0,
+        ancestorMode: searchSettings.ancestorMode || 'from-root',
         page: 1,
-        limit: 100
+        limitEnabled,
+        ...(limitEnabled ? { limit: limitValue } : {})
       };
       
       console.log('Search params being sent:', searchParams); // Debug log
@@ -257,7 +265,19 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
   const handleSaveSettings = async () => {
     try {
       const values = await settingsForm.validateFields();
-      setSearchSettings(values);
+      const limitFromForm = Number(values.limit);
+      const existingLimit = Number.isFinite(Number(searchSettings.limit)) && Number(searchSettings.limit) > 0
+        ? Number(searchSettings.limit)
+        : 100;
+      const normalizedValues = {
+        ...values,
+        limitEnabled: values.limitEnabled !== false,
+        limit: Number.isFinite(limitFromForm) && limitFromForm > 0
+          ? limitFromForm
+          : existingLimit
+      };
+      setSearchSettings(normalizedValues);
+      settingsForm.setFieldsValue(normalizedValues);
       setSettingsModalVisible(false);
       message.success('Search settings saved successfully!');
     } catch (error) {
@@ -439,6 +459,43 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
                 rules={[{ type: 'number', min: 0, max: 20 }]}
               >
                 <InputNumber min={0} max={20} style={{ width: '100%' }} />
+              </Form.Item>
+            </Col>
+          </Row>
+
+          <Row gutter={16}>
+            <Col span={24}>
+              <Form.Item
+                label="Result Limit"
+                tooltip="Set the maximum number of results per search. Disable to fetch all matches (may impact performance)."
+                shouldUpdate={(prev, curr) => prev.limitEnabled !== curr.limitEnabled}
+              >
+                {({ getFieldValue }) => {
+                  const limitEnabledValue = getFieldValue('limitEnabled') !== false;
+                  return (
+                    <Space align="center">
+                      <Form.Item name="limitEnabled" valuePropName="checked" noStyle>
+                        <Checkbox>Enable</Checkbox>
+                      </Form.Item>
+                      <Form.Item
+                        name="limit"
+                        noStyle
+                        rules={limitEnabledValue ? [
+                          { required: true, message: 'Please enter a result limit' },
+                          { type: 'number', min: 1, message: 'Limit must be at least 1' }
+                        ] : []}
+                      >
+                        <InputNumber
+                          min={1}
+                          step={1}
+                          precision={0}
+                          disabled={!limitEnabledValue}
+                          style={{ width: 140 }}
+                        />
+                      </Form.Item>
+                    </Space>
+                  );
+                }}
               </Form.Item>
             </Col>
           </Row>

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -139,11 +139,24 @@ router.get('/', (req, res) => {
   ancestorLevels = '0',
     ancestorMode = 'from-root', // 'from-root' | 'from-match'
       page = 1,
-      limit = 100
+      limit = 100,
+      limitEnabled = 'true'
     } = req.query;
 
-    const offset = (parseInt(page) - 1) * parseInt(limit);
-    const limitNum = parseInt(limit);
+    const parsedPage = parseInt(page, 10);
+    const pageNum = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
+
+    const isLimitEnabled = limitEnabled !== 'false';
+
+    let limitNum = parseInt(limit, 10);
+    if (!isLimitEnabled) {
+      limitNum = null;
+    } else if (!Number.isFinite(limitNum) || limitNum <= 0) {
+      limitNum = 100;
+    }
+
+    const offset = isLimitEnabled ? (pageNum - 1) * limitNum : 0;
+    const limitClause = isLimitEnabled ? 'LIMIT ? OFFSET ?' : '';
 
     let results = { folders: [], files: [], totalFolders: 0, totalFiles: 0 };
 
@@ -272,14 +285,16 @@ router.get('/', (req, res) => {
       const folderQuery = `
         ${baseFolderQuery}
         ORDER BY path
-        LIMIT ? OFFSET ?
+        ${limitClause}
       `;
 
       const countQuery = `
         SELECT COUNT(*) as count FROM folders WHERE user_id = ? ${whereClause}
       `;
 
-      db.all(folderQuery, [...params, limitNum, offset], (err, folders) => {
+      const folderParams = isLimitEnabled ? [...params, limitNum, offset] : params;
+
+      db.all(folderQuery, folderParams, (err, folders) => {
         if (err) {
           console.warn('Folder search error:', err.message);
           results.folders = [];
@@ -502,7 +517,7 @@ router.get('/', (req, res) => {
         LEFT JOIN folders ON f.folder_id = folders.id
         WHERE folders.user_id = ? ${fileWhereClause}
         ORDER BY folders.path, f.name
-        LIMIT ? OFFSET ?
+        ${limitClause}
       `;
       
       const fileCountQuery = `
@@ -512,7 +527,9 @@ router.get('/', (req, res) => {
         WHERE folders.user_id = ? ${fileWhereClause}
       `;
 
-      db.all(fileQuery, [...fileParams, limitNum, offset], (err, files) => {
+      const fileQueryParams = isLimitEnabled ? [...fileParams, limitNum, offset] : fileParams;
+
+      db.all(fileQuery, fileQueryParams, (err, files) => {
         if (err) {
           console.warn('File search error:', err.message);
           results.files = [];
@@ -535,10 +552,16 @@ router.get('/', (req, res) => {
 
     function sendResults() {
       // Add pagination info
+      const totalItems = (results.totalFolders || 0) + (results.totalFiles || 0);
+      const totalPages = isLimitEnabled
+        ? Math.ceil(totalItems / (limitNum || 1))
+        : (totalItems > 0 ? 1 : 0);
+
       results.pagination = {
-        page: parseInt(page),
-        limit: limitNum,
-        totalPages: Math.ceil((results.totalFolders + results.totalFiles) / limitNum)
+        page: pageNum,
+        limit: isLimitEnabled ? limitNum : null,
+        totalPages,
+        limitEnabled: isLimitEnabled
       };
 
       res.json(results);


### PR DESCRIPTION
## Summary
- add a toggleable result limit input to the search settings modal and persist the new settings when running a search
- respect unlimited searches in the client by skipping pagination requests and adjusting the results footer copy
- update the search API to honour the new `limitEnabled` flag and drop SQL limits when it is disabled

## Testing
- npm --prefix client test -- --watchAll=false *(fails: react-scripts not found because dependencies are unavailable)*
- npm --prefix client install *(fails: registry returned 403 when fetching typescript)*

------
https://chatgpt.com/codex/tasks/task_e_68d1774834788332a024b620c1d56703