### PR TITLE
Refine limit toggle handling

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -14,6 +14,7 @@ import DeleteMode from './components/DeleteMode';
 import AddFilesMode from './components/AddFilesMode';
 import SearchPanel from './components/SearchPanel';
 import { ApiService } from './services/api';
+import { isLimitEnabled, normalizeLimitValue } from './utils/searchSettings';
 
 const { Header, Content } = Layout;
 
@@ -44,13 +45,23 @@ const MainApp = () => {
   const handleSearch = async (searchParams) => {
     setLoadingData(true);
     try {
+      const limitEnabled = isLimitEnabled(searchParams.limitEnabled);
+      const normalizedLimit = normalizeLimitValue(searchParams.limit);
+
       // Add default pagination if not provided
       const searchWithPagination = {
         ...searchParams,
-        page: searchParams.page || 1,
-        limit: searchParams.limit || 100
+        page: searchParams.page || 1
       };
-      
+
+      if (limitEnabled) {
+        searchWithPagination.limit = normalizedLimit;
+        searchWithPagination.limitEnabled = true;
+      } else {
+        delete searchWithPagination.limit;
+        searchWithPagination.limitEnabled = false;
+      }
+
       const results = await ApiService.search(searchWithPagination);
       setSearchResults({ ...results, isNewSearch: true });
       setCurrentSearchParams(searchWithPagination);
@@ -64,7 +75,12 @@ const MainApp = () => {
 
   const handlePageChange = async (paginationParams) => {
     if (!currentSearchParams) return;
-    
+
+    const limitEnabled = isLimitEnabled(currentSearchParams.limitEnabled);
+    if (!limitEnabled) {
+      return;
+    }
+
     setLoadingData(true);
     try {
       const searchWithNewPagination = {

--- a/client/src/components/FileMode.js
+++ b/client/src/components/FileMode.js
@@ -10,6 +10,7 @@ import {
   message
 } from 'antd';
 import { copyToClipboard } from '../utils/clipboard';
+import { isLimitEnabled } from '../utils/searchSettings';
 import { 
   CopyOutlined,
   ExportOutlined,
@@ -179,9 +180,9 @@ const FileMode = ({ searchResults, refreshTrigger, onPageChange }) => {
       pageSize: paginationConfig.pageSize,
     };
     setPagination(newPagination);
-    
+
     // Call parent callback to refetch data with new pagination
-    if (onPageChange) {
+    if (onPageChange && isLimitEnabled(searchResults?.pagination?.limitEnabled)) {
       onPageChange({
         page: paginationConfig.current,
         limit: paginationConfig.pageSize
@@ -193,9 +194,14 @@ const FileMode = ({ searchResults, refreshTrigger, onPageChange }) => {
     if (searchResults?.files) {
       // Use backend total for proper pagination
       const backendTotal = searchResults.totalFiles || searchResults.files.length;
+      const limitEnabled = isLimitEnabled(searchResults.pagination?.limitEnabled);
+
       setPagination(prev => ({
         ...prev,
         total: backendTotal,
+        pageSize: limitEnabled
+          ? (searchResults.pagination?.limit || prev.pageSize)
+          : prev.pageSize,
         // Reset to page 1 only if it's a new search (not pagination)
         current: searchResults.isNewSearch ? 1 : prev.current
       }));
@@ -214,6 +220,7 @@ const FileMode = ({ searchResults, refreshTrigger, onPageChange }) => {
   }
 
   const files = searchResults.files || [];
+  const paginationLimitEnabled = isLimitEnabled(searchResults.pagination?.limitEnabled);
 
   return (
     <Card 
@@ -250,11 +257,13 @@ const FileMode = ({ searchResults, refreshTrigger, onPageChange }) => {
             scroll={{ x: 1200 }}
             size="small"
           />
-          
+
           {searchResults.pagination && (
             <div style={{ marginTop: 16, textAlign: 'center' }}>
               <Text type="secondary">
-                Showing page {searchResults.pagination.page} of {searchResults.pagination.totalPages}
+                {!paginationLimitEnabled
+                  ? 'Showing all results (no limit applied)'
+                  : `Showing page ${searchResults.pagination.page} of ${searchResults.pagination.totalPages}`}
               </Text>
             </div>
           )}

--- a/client/src/components/SearchPanel.js
+++ b/client/src/components/SearchPanel.js
@@ -12,7 +12,8 @@ import {
   DatePicker,
   Modal,
   Space,
-  message
+  message,
+  Checkbox
 } from 'antd';
 import {
   SearchOutlined,
@@ -25,6 +26,7 @@ import {
   SettingOutlined
 } from '@ant-design/icons';
 import { ApiService } from '../services/api';
+import { isLimitEnabled, normalizeLimitValue } from '../utils/searchSettings';
 
 const { Option } = Select;
 const { RangePicker } = DatePicker;
@@ -48,9 +50,11 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
     caseSensitive: false,
     extension: '',
     sizeRange: undefined,
-  dateRange: undefined,
-  ancestorLevels: 0,
-  ancestorMode: 'from-root'
+    dateRange: undefined,
+    ancestorLevels: 0,
+    ancestorMode: 'from-root',
+    limitEnabled: true,
+    limit: 100
   });
   
   // Create form instances - warnings will be suppressed by destroyOnClose
@@ -149,6 +153,9 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
       }
       const searchValues = await searchForm.validateFields(['query']);
       
+      const limitEnabled = isLimitEnabled(searchSettings.limitEnabled);
+      const limitValue = normalizeLimitValue(searchSettings.limit);
+
       const searchParams = {
         query: searchValues.query || '',
         mode: searchSettings.mode || 'contains',
@@ -160,10 +167,11 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
         sizeMax: searchSettings.sizeRange?.[1] || '',
         dateFrom: searchSettings.dateRange?.[0]?.format('YYYY-MM-DD') || '',
         dateTo: searchSettings.dateRange?.[1]?.format('YYYY-MM-DD') || '',
-  ancestorLevels: Number.isFinite(Number(searchSettings.ancestorLevels)) ? Number(searchSettings.ancestorLevels) : 0,
-  ancestorMode: searchSettings.ancestorMode || 'from-root',
+        ancestorLevels: Number.isFinite(Number(searchSettings.ancestorLevels)) ? Number(searchSettings.ancestorLevels) : 0,
+        ancestorMode: searchSettings.ancestorMode || 'from-root',
         page: 1,
-        limit: 100
+        limitEnabled,
+        ...(limitEnabled ? { limit: limitValue } : {})
       };
       
       console.log('Search params being sent:', searchParams); // Debug log
@@ -257,7 +265,15 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
   const handleSaveSettings = async () => {
     try {
       const values = await settingsForm.validateFields();
-      setSearchSettings(values);
+      const limitEnabled = isLimitEnabled(values.limitEnabled);
+      const existingLimit = normalizeLimitValue(searchSettings.limit);
+      const normalizedValues = {
+        ...values,
+        limitEnabled,
+        limit: normalizeLimitValue(values.limit, existingLimit)
+      };
+      setSearchSettings(normalizedValues);
+      settingsForm.setFieldsValue(normalizedValues);
       setSettingsModalVisible(false);
       message.success('Search settings saved successfully!');
     } catch (error) {
@@ -439,6 +455,43 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
                 rules={[{ type: 'number', min: 0, max: 20 }]}
               >
                 <InputNumber min={0} max={20} style={{ width: '100%' }} />
+              </Form.Item>
+            </Col>
+          </Row>
+
+          <Row gutter={16}>
+            <Col span={24}>
+              <Form.Item
+                label="Result Limit"
+                tooltip="Set the maximum number of results per search. Disable to fetch all matches (may impact performance)."
+                shouldUpdate={(prev, curr) => prev.limitEnabled !== curr.limitEnabled}
+              >
+                {({ getFieldValue }) => {
+                  const limitEnabledValue = isLimitEnabled(getFieldValue('limitEnabled'));
+                  return (
+                    <Space align="center">
+                      <Form.Item name="limitEnabled" valuePropName="checked" noStyle>
+                        <Checkbox>Enable</Checkbox>
+                      </Form.Item>
+                      <Form.Item
+                        name="limit"
+                        noStyle
+                        rules={limitEnabledValue ? [
+                          { required: true, message: 'Please enter a result limit' },
+                          { type: 'number', min: 1, message: 'Limit must be at least 1' }
+                        ] : []}
+                      >
+                        <InputNumber
+                          min={1}
+                          step={1}
+                          precision={0}
+                          disabled={!limitEnabledValue}
+                          style={{ width: 140 }}
+                        />
+                      </Form.Item>
+                    </Space>
+                  );
+                }}
               </Form.Item>
             </Col>
           </Row>

--- a/client/src/utils/searchSettings.js
+++ b/client/src/utils/searchSettings.js
@@ -1,0 +1,14 @@
+export const isLimitEnabled = (value, defaultValue = true) => {
+  if (value === false || value === 'false') {
+    return false;
+  }
+  if (value === true || value === 'true') {
+    return true;
+  }
+  return defaultValue;
+};
+
+export const normalizeLimitValue = (value, fallback = 100) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -139,11 +139,24 @@ router.get('/', (req, res) => {
   ancestorLevels = '0',
     ancestorMode = 'from-root', // 'from-root' | 'from-match'
       page = 1,
-      limit = 100
+      limit = 100,
+      limitEnabled = 'true'
     } = req.query;
 
-    const offset = (parseInt(page) - 1) * parseInt(limit);
-    const limitNum = parseInt(limit);
+    const parsedPage = parseInt(page, 10);
+    const pageNum = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
+
+    const isLimitEnabled = !(limitEnabled === false || limitEnabled === 'false');
+
+    let limitNum = parseInt(limit, 10);
+    if (!isLimitEnabled) {
+      limitNum = null;
+    } else if (!Number.isFinite(limitNum) || limitNum <= 0) {
+      limitNum = 100;
+    }
+
+    const offset = isLimitEnabled ? (pageNum - 1) * limitNum : 0;
+    const limitClause = isLimitEnabled ? 'LIMIT ? OFFSET ?' : '';
 
     let results = { folders: [], files: [], totalFolders: 0, totalFiles: 0 };
 
@@ -272,14 +285,16 @@ router.get('/', (req, res) => {
       const folderQuery = `
         ${baseFolderQuery}
         ORDER BY path
-        LIMIT ? OFFSET ?
+        ${limitClause}
       `;
 
       const countQuery = `
         SELECT COUNT(*) as count FROM folders WHERE user_id = ? ${whereClause}
       `;
 
-      db.all(folderQuery, [...params, limitNum, offset], (err, folders) => {
+      const folderParams = isLimitEnabled ? [...params, limitNum, offset] : params;
+
+      db.all(folderQuery, folderParams, (err, folders) => {
         if (err) {
           console.warn('Folder search error:', err.message);
           results.folders = [];
@@ -502,7 +517,7 @@ router.get('/', (req, res) => {
         LEFT JOIN folders ON f.folder_id = folders.id
         WHERE folders.user_id = ? ${fileWhereClause}
         ORDER BY folders.path, f.name
-        LIMIT ? OFFSET ?
+        ${limitClause}
       `;
       
       const fileCountQuery = `
@@ -512,7 +527,9 @@ router.get('/', (req, res) => {
         WHERE folders.user_id = ? ${fileWhereClause}
       `;
 
-      db.all(fileQuery, [...fileParams, limitNum, offset], (err, files) => {
+      const fileQueryParams = isLimitEnabled ? [...fileParams, limitNum, offset] : fileParams;
+
+      db.all(fileQuery, fileQueryParams, (err, files) => {
         if (err) {
           console.warn('File search error:', err.message);
           results.files = [];
@@ -535,10 +552,17 @@ router.get('/', (req, res) => {
 
     function sendResults() {
       // Add pagination info
+      const totalItems = (results.totalFolders || 0) + (results.totalFiles || 0);
+      const safeLimit = Number.isFinite(limitNum) && limitNum > 0 ? limitNum : 1;
+      const totalPages = isLimitEnabled
+        ? Math.ceil(totalItems / safeLimit)
+        : (totalItems > 0 ? 1 : 0);
+
       results.pagination = {
-        page: parseInt(page),
-        limit: limitNum,
-        totalPages: Math.ceil((results.totalFolders + results.totalFiles) / limitNum)
+        page: pageNum,
+        limit: isLimitEnabled ? limitNum : null,
+        totalPages,
+        limitEnabled: isLimitEnabled
       };
 
       res.json(results);


### PR DESCRIPTION
## Summary
- add shared helpers to normalize limit toggle and value handling and use them across the client so unlimited mode stays consistent
- update the search settings modal logic to reuse the helpers and reduce redundant number coercions
- harden the search API pagination metadata by normalizing the limit flag and avoiding divide-by-zero when the limit is invalid

## Testing
- npm --prefix client test -- --watchAll=false *(fails: react-scripts not found because frontend dependencies are unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68d1774834788332a024b620c1d56703