### PR TITLE
Add admin user management dashboard and fix profile bug

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -14,6 +14,7 @@ import DeleteMode from './components/DeleteMode';
 import AddFilesMode from './components/AddFilesMode';
 import SearchPanel from './components/SearchPanel';
 import { ApiService } from './services/api';
+import AdminUserManagement from './components/AdminUserManagement';
 
 const { Header, Content } = Layout;
 
@@ -118,6 +119,8 @@ const MainApp = () => {
     setCurrentSearchParams(null);
   };
 
+  const isAdmin = user?.is_admin === 1 || user?.is_admin === true || user?.isAdmin;
+
   const userMenuItems = [
     {
       key: 'profile',
@@ -194,6 +197,14 @@ const MainApp = () => {
       )
     }
   ];
+
+  if (isAdmin) {
+    tabItems.push({
+      key: 'admin',
+      label: 'Admin',
+      children: <AdminUserManagement currentUser={user} />
+    });
+  }
 
   return (
     <Layout style={{ minHeight: '100vh' }}>

--- a/client/src/components/AdminUserManagement.js
+++ b/client/src/components/AdminUserManagement.js
@@ -1,0 +1,291 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Card,
+  Form,
+  Input,
+  message,
+  Modal,
+  Popconfirm,
+  Space,
+  Table,
+  Tag,
+  Typography
+} from 'antd';
+import {
+  DeleteOutlined,
+  LockOutlined,
+  ReloadOutlined
+} from '@ant-design/icons';
+import moment from 'moment';
+
+import { ApiService } from '../services/api';
+
+const { Text } = Typography;
+
+const formatDateTime = (value) => {
+  if (!value) {
+    return <Text type="secondary">Never</Text>;
+  }
+  return moment(value).format('YYYY-MM-DD HH:mm');
+};
+
+const numberRenderer = (value) => (value ?? 0).toLocaleString();
+
+const AdminUserManagement = ({ currentUser }) => {
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [passwordModalVisible, setPasswordModalVisible] = useState(false);
+  const [selectedUser, setSelectedUser] = useState(null);
+  const [passwordLoading, setPasswordLoading] = useState(false);
+  const [deletingUserId, setDeletingUserId] = useState(null);
+  const [form] = Form.useForm();
+
+  const fetchUsers = async () => {
+    setLoading(true);
+    try {
+      const response = await ApiService.getAdminUsers();
+      setUsers(response?.users || []);
+    } catch (error) {
+      console.error('Failed to load admin users', error);
+      message.error(error.message || 'Failed to load users');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUsers();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const totals = useMemo(() => {
+    return users.reduce(
+      (acc, user) => {
+        acc.totalScans += user.scanCount || 0;
+        acc.totalData += user.dataCount || 0;
+        return acc;
+      },
+      { totalScans: 0, totalData: 0 }
+    );
+  }, [users]);
+
+  const openPasswordModal = (user) => {
+    setSelectedUser(user);
+    setPasswordModalVisible(true);
+    form.resetFields();
+  };
+
+  const handlePasswordUpdate = async () => {
+    try {
+      const values = await form.validateFields();
+      setPasswordLoading(true);
+      await ApiService.updateUserPassword(selectedUser.id, values.newPassword);
+      message.success('Password updated successfully');
+      setPasswordModalVisible(false);
+      form.resetFields();
+      fetchUsers();
+    } catch (error) {
+      if (error?.errorFields) {
+        return;
+      }
+      console.error('Failed to update password', error);
+      message.error(error.message || 'Failed to update password');
+    } finally {
+      setPasswordLoading(false);
+    }
+  };
+
+  const handleDeleteUser = async (user) => {
+    try {
+      setDeletingUserId(user.id);
+      await ApiService.deleteUser(user.id);
+      message.success('User deleted successfully');
+      fetchUsers();
+    } catch (error) {
+      console.error('Failed to delete user', error);
+      message.error(error.message || 'Failed to delete user');
+    } finally {
+      setDeletingUserId(null);
+    }
+  };
+
+  const columns = [
+    {
+      title: 'Username',
+      dataIndex: 'username',
+      key: 'username',
+      render: (value, record) => (
+        <Space>
+          <Text strong>{value}</Text>
+          {record.isAdmin && <Tag color="gold">Admin</Tag>}
+          {record.id === currentUser?.id && <Tag color="blue">You</Tag>}
+        </Space>
+      ),
+    },
+    {
+      title: 'Email',
+      dataIndex: 'email',
+      key: 'email',
+      render: (value) => value || <Text type="secondary">Not set</Text>,
+    },
+    {
+      title: 'Created At',
+      dataIndex: 'createdAt',
+      key: 'createdAt',
+      render: formatDateTime,
+    },
+    {
+      title: 'Last Login',
+      dataIndex: 'lastLogin',
+      key: 'lastLogin',
+      render: formatDateTime,
+    },
+    {
+      title: 'Total Scans',
+      dataIndex: 'scanCount',
+      key: 'scanCount',
+      render: numberRenderer,
+      sorter: (a, b) => (a.scanCount || 0) - (b.scanCount || 0),
+      defaultSortOrder: 'descend',
+    },
+    {
+      title: 'Total Data',
+      dataIndex: 'dataCount',
+      key: 'dataCount',
+      render: numberRenderer,
+      sorter: (a, b) => (a.dataCount || 0) - (b.dataCount || 0),
+    },
+    {
+      title: 'Folders',
+      dataIndex: 'folderCount',
+      key: 'folderCount',
+      render: numberRenderer,
+      responsive: ['lg'],
+    },
+    {
+      title: 'Files',
+      dataIndex: 'fileCount',
+      key: 'fileCount',
+      render: numberRenderer,
+      responsive: ['lg'],
+    },
+    {
+      title: 'Actions',
+      key: 'actions',
+      render: (_, record) => {
+        const isCurrentUser = record.id === currentUser?.id;
+
+        return (
+          <Space>
+            <Button
+              type="link"
+              icon={<LockOutlined />}
+              onClick={() => openPasswordModal(record)}
+            >
+              Reset Password
+            </Button>
+            <Popconfirm
+              title="Delete account"
+              description={`Are you sure you want to delete ${record.username}? This will remove all of their data.`}
+              onConfirm={() => handleDeleteUser(record)}
+              okButtonProps={{ danger: true }}
+              okText="Delete"
+              cancelText="Cancel"
+              disabled={isCurrentUser}
+            >
+              <Button
+                type="link"
+                danger
+                icon={<DeleteOutlined />}
+                disabled={isCurrentUser}
+                loading={deletingUserId === record.id}
+              >
+                Delete
+              </Button>
+            </Popconfirm>
+          </Space>
+        );
+      },
+    },
+  ];
+
+  return (
+    <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <Card
+        title="Accounts overview"
+        extra={(
+          <Button
+            icon={<ReloadOutlined />}
+            onClick={fetchUsers}
+            loading={loading}
+          >
+            Refresh
+          </Button>
+        )}
+      >
+        <Space size="large">
+          <Text strong>Total accounts:</Text>
+          <Text>{users.length}</Text>
+          <Text strong>Total scans:</Text>
+          <Text>{totals.totalScans.toLocaleString()}</Text>
+          <Text strong>Total data entries:</Text>
+          <Text>{totals.totalData.toLocaleString()}</Text>
+        </Space>
+      </Card>
+
+      <Card>
+        <Table
+          rowKey="id"
+          loading={loading}
+          dataSource={users}
+          columns={columns}
+          pagination={{ pageSize: 8, showSizeChanger: true }}
+        />
+      </Card>
+
+      <Modal
+        title={selectedUser ? `Reset password for ${selectedUser.username}` : 'Reset password'}
+        open={passwordModalVisible}
+        onOk={handlePasswordUpdate}
+        confirmLoading={passwordLoading}
+        onCancel={() => setPasswordModalVisible(false)}
+        okText="Update password"
+      >
+        <Form form={form} layout="vertical">
+          <Form.Item
+            label="New password"
+            name="newPassword"
+            rules={[
+              { required: true, message: 'Please enter a new password' },
+              { min: 6, message: 'Password must be at least 6 characters' }
+            ]}
+          >
+            <Input.Password autoComplete="new-password" />
+          </Form.Item>
+          <Form.Item
+            label="Confirm new password"
+            name="confirmPassword"
+            dependencies={['newPassword']}
+            rules={[
+              { required: true, message: 'Please confirm the new password' },
+              ({ getFieldValue }) => ({
+                validator(_, value) {
+                  if (!value || getFieldValue('newPassword') === value) {
+                    return Promise.resolve();
+                  }
+                  return Promise.reject(new Error('Passwords do not match'));
+                },
+              })
+            ]}
+          >
+            <Input.Password autoComplete="new-password" />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </Space>
+  );
+};
+
+export default AdminUserManagement;
+

--- a/client/src/contexts/AuthContext.js
+++ b/client/src/contexts/AuthContext.js
@@ -33,12 +33,18 @@ export const AuthProvider = ({ children }) => {
 
         if (response.ok) {
           const profileResponse = await response.json();
-          const profileUser = profileResponse?.user || profileResponse;
 
-          if (profileUser && profileUser.username) {
-            setUser(profileUser);
+          if (profileResponse && typeof profileResponse === 'object') {
+            if (profileResponse.user && profileResponse.user.username) {
+              setUser(profileResponse.user);
+            } else if (profileResponse.username) {
+              setUser(profileResponse);
+            } else {
+              console.warn('Received unexpected profile response shape:', profileResponse);
+              logout();
+            }
           } else {
-            console.warn('Received unexpected profile response', profileResponse);
+            console.warn('Received non-object profile response:', profileResponse);
             logout();
           }
         } else {

--- a/client/src/contexts/AuthContext.js
+++ b/client/src/contexts/AuthContext.js
@@ -32,8 +32,15 @@ export const AuthProvider = ({ children }) => {
         });
 
         if (response.ok) {
-          const userData = await response.json();
-          setUser(userData);
+          const profileResponse = await response.json();
+          const profileUser = profileResponse?.user || profileResponse;
+
+          if (profileUser && profileUser.username) {
+            setUser(profileUser);
+          } else {
+            console.warn('Received unexpected profile response', profileResponse);
+            logout();
+          }
         } else {
           // Token is invalid
           logout();

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -140,4 +140,22 @@ export class ApiService {
       body: JSON.stringify(folderData)
     });
   }
+
+  // Admin operations
+  static async getAdminUsers() {
+    return this.request('/admin/users');
+  }
+
+  static async updateUserPassword(userId, newPassword) {
+    return this.request(`/admin/users/${userId}/password`, {
+      method: 'PUT',
+      body: JSON.stringify({ newPassword })
+    });
+  }
+
+  static async deleteUser(userId) {
+    return this.request(`/admin/users/${userId}`, {
+      method: 'DELETE'
+    });
+  }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -28,7 +28,7 @@ db.run('PRAGMA foreign_keys = ON');
 app.locals.db = db;
 
 // Import authentication middleware
-const { authenticateToken, extractUserId } = require('./middleware/auth');
+const { authenticateToken, extractUserId, requireAdmin } = require('./middleware/auth');
 
 // Import routes
 const authRoutes = require('./routes/auth');
@@ -37,6 +37,7 @@ const searchRoutes = require('./routes/search');
 const statsRoutes = require('./routes/stats');
 const deleteRoutes = require('./routes/delete');
 const addRoutes = require('./routes/add');
+const adminRoutes = require('./routes/admin');
 
 // Public routes (no authentication required)
 app.use('/api/auth', authRoutes);
@@ -52,6 +53,7 @@ app.use('/api/search', authenticateToken, extractUserId, searchRoutes);
 app.use('/api/stats', authenticateToken, extractUserId, statsRoutes);
 app.use('/api/delete', authenticateToken, extractUserId, deleteRoutes);
 app.use('/api/add', authenticateToken, extractUserId, addRoutes);
+app.use('/api/admin', authenticateToken, requireAdmin, adminRoutes);
 
 // Serve React app for any non-API routes (only if build exists)
 app.get('*', (req, res) => {

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -1,25 +1,12 @@
 const express = require('express');
 const bcrypt = require('bcryptjs');
+const { authenticateToken, requireAdmin } = require('../middleware/auth');
 
 const router = express.Router();
 
-const ensureAdminAccess = (req, res, next) => {
-  if (!req.user) {
-    return res.status(401).json({
-      error: 'Authentication required',
-      message: 'You must be logged in to access admin resources'
-    });
-  }
-
-  if (req.user.is_admin !== 1) {
-    return res.status(403).json({
-      error: 'Admin privileges required',
-      message: 'You need admin permissions to perform this action'
-    });
-  }
-
-  next();
-};
+// Ensure all admin routes are executed behind authentication and admin checks.
+router.use(authenticateToken);
+router.use(requireAdmin);
 
 const runAsync = (db, sql, params = []) =>
   new Promise((resolve, reject) => {
@@ -42,8 +29,6 @@ const getAsync = (db, sql, params = []) =>
       }
     });
   });
-
-router.use(ensureAdminAccess);
 
 // Get aggregated statistics for all users
 router.get('/users', (req, res) => {

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -3,6 +3,48 @@ const bcrypt = require('bcryptjs');
 
 const router = express.Router();
 
+const ensureAdminAccess = (req, res, next) => {
+  if (!req.user) {
+    return res.status(401).json({
+      error: 'Authentication required',
+      message: 'You must be logged in to access admin resources'
+    });
+  }
+
+  if (req.user.is_admin !== 1) {
+    return res.status(403).json({
+      error: 'Admin privileges required',
+      message: 'You need admin permissions to perform this action'
+    });
+  }
+
+  next();
+};
+
+const runAsync = (db, sql, params = []) =>
+  new Promise((resolve, reject) => {
+    db.run(sql, params, function(err) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(this);
+      }
+    });
+  });
+
+const getAsync = (db, sql, params = []) =>
+  new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(row);
+      }
+    });
+  });
+
+router.use(ensureAdminAccess);
+
 // Get aggregated statistics for all users
 router.get('/users', (req, res) => {
   const db = req.app.locals.db;
@@ -107,7 +149,7 @@ router.put('/users/:id/password', async (req, res) => {
 });
 
 // Delete a user and all of their related data
-router.delete('/users/:id', (req, res) => {
+router.delete('/users/:id', async (req, res) => {
   const db = req.app.locals.db;
   const userId = parseInt(req.params.id, 10);
 
@@ -122,18 +164,43 @@ router.delete('/users/:id', (req, res) => {
     });
   }
 
-  db.run('DELETE FROM users WHERE id = ?', [userId], function(err) {
-    if (err) {
-      console.error('Failed to delete user:', err);
-      return res.status(500).json({ error: 'Failed to delete user' });
-    }
+  let transactionStarted = false;
 
-    if (this.changes === 0) {
+  try {
+    const existingUser = await getAsync(db, 'SELECT id FROM users WHERE id = ?', [userId]);
+
+    if (!existingUser) {
       return res.status(404).json({ error: 'User not found' });
     }
 
+    await runAsync(db, 'BEGIN TRANSACTION');
+    transactionStarted = true;
+
+    await runAsync(
+      db,
+      'DELETE FROM files WHERE folder_id IN (SELECT id FROM folders WHERE user_id = ?)',
+      [userId]
+    );
+
+    await runAsync(db, 'DELETE FROM folders WHERE user_id = ?', [userId]);
+    await runAsync(db, 'DELETE FROM scans WHERE user_id = ?', [userId]);
+    await runAsync(db, 'DELETE FROM users WHERE id = ?', [userId]);
+    await runAsync(db, 'COMMIT');
+
     res.json({ success: true, message: 'User deleted successfully' });
-  });
+  } catch (error) {
+    console.error('Failed to delete user and related data:', error);
+
+    if (transactionStarted) {
+      try {
+        await runAsync(db, 'ROLLBACK');
+      } catch (rollbackError) {
+        console.error('Failed to rollback transaction:', rollbackError);
+      }
+    }
+
+    res.status(500).json({ error: 'Failed to delete user' });
+  }
 });
 
 module.exports = router;

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -1,0 +1,140 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+
+const router = express.Router();
+
+// Get aggregated statistics for all users
+router.get('/users', (req, res) => {
+  const db = req.app.locals.db;
+
+  const query = `
+    SELECT 
+      u.id,
+      u.username,
+      u.email,
+      u.is_admin AS isAdmin,
+      u.created_at AS createdAt,
+      u.updated_at AS updatedAt,
+      u.last_login AS lastLogin,
+      COALESCE(scan_stats.scan_count, 0) AS scanCount,
+      COALESCE(folder_stats.folder_count, 0) AS folderCount,
+      COALESCE(file_stats.file_count, 0) AS fileCount,
+      COALESCE(folder_stats.folder_count, 0) + COALESCE(file_stats.file_count, 0) AS dataCount
+    FROM users u
+    LEFT JOIN (
+      SELECT user_id, COUNT(*) AS scan_count
+      FROM scans
+      GROUP BY user_id
+    ) AS scan_stats ON scan_stats.user_id = u.id
+    LEFT JOIN (
+      SELECT user_id, COUNT(*) AS folder_count
+      FROM folders
+      GROUP BY user_id
+    ) AS folder_stats ON folder_stats.user_id = u.id
+    LEFT JOIN (
+      SELECT flds.user_id, COUNT(fls.id) AS file_count
+      FROM files fls
+      INNER JOIN folders flds ON flds.id = fls.folder_id
+      GROUP BY flds.user_id
+    ) AS file_stats ON file_stats.user_id = u.id
+    ORDER BY u.created_at ASC
+  `;
+
+  db.all(query, [], (err, rows) => {
+    if (err) {
+      console.error('Failed to fetch users for admin panel:', err);
+      return res.status(500).json({ error: 'Failed to fetch users' });
+    }
+
+    const users = rows.map((row) => ({
+      id: row.id,
+      username: row.username,
+      email: row.email,
+      isAdmin: row.isAdmin === 1,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      lastLogin: row.lastLogin,
+      scanCount: row.scanCount,
+      folderCount: row.folderCount,
+      fileCount: row.fileCount,
+      dataCount: row.dataCount
+    }));
+
+    res.json({ success: true, users });
+  });
+});
+
+// Update user password (admin reset)
+router.put('/users/:id/password', async (req, res) => {
+  const db = req.app.locals.db;
+  const userId = parseInt(req.params.id, 10);
+  const { newPassword } = req.body;
+
+  if (!Number.isInteger(userId)) {
+    return res.status(400).json({ error: 'Invalid user ID' });
+  }
+
+  if (!newPassword || newPassword.length < 6) {
+    return res.status(400).json({
+      error: 'Invalid password',
+      message: 'New password must be at least 6 characters long'
+    });
+  }
+
+  try {
+    const hashedPassword = await bcrypt.hash(newPassword, 10);
+
+    db.run(
+      'UPDATE users SET password = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
+      [hashedPassword, userId],
+      function(err) {
+        if (err) {
+          console.error('Failed to update user password:', err);
+          return res.status(500).json({ error: 'Failed to update password' });
+        }
+
+        if (this.changes === 0) {
+          return res.status(404).json({ error: 'User not found' });
+        }
+
+        res.json({ success: true, message: 'Password updated successfully' });
+      }
+    );
+  } catch (error) {
+    console.error('Password hashing failed:', error);
+    res.status(500).json({ error: 'Failed to process password' });
+  }
+});
+
+// Delete a user and all of their related data
+router.delete('/users/:id', (req, res) => {
+  const db = req.app.locals.db;
+  const userId = parseInt(req.params.id, 10);
+
+  if (!Number.isInteger(userId)) {
+    return res.status(400).json({ error: 'Invalid user ID' });
+  }
+
+  if (userId === req.user.id) {
+    return res.status(400).json({
+      error: 'Cannot delete active account',
+      message: 'You cannot delete the account currently logged in'
+    });
+  }
+
+  db.run('DELETE FROM users WHERE id = ?', [userId], function(err) {
+    if (err) {
+      console.error('Failed to delete user:', err);
+      return res.status(500).json({ error: 'Failed to delete user' });
+    }
+
+    if (this.changes === 0) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    res.json({ success: true, message: 'User deleted successfully' });
+  });
+});
+
+module.exports = router;
+


### PR DESCRIPTION
## Summary
- ensure the auth context stores the parsed user profile to eliminate the undefined username header state
- add secured admin API endpoints that aggregate user statistics and allow password resets or full account deletion with cascading cleanup
- introduce an admin dashboard tab on the client that lists account metrics and exposes password reset and delete actions using the new API helpers

## Testing
- npm --prefix client test -- --watchAll=false *(fails: react-scripts not found without installing client dependencies)*
- npm --prefix client install *(fails: 403 Forbidden when fetching the typescript package from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a2e87e5083328c84e90f0f6c9046