### PR TITLE
Add search trim toggle setting

### DIFF
--- a/client/src/components/SearchPanel.js
+++ b/client/src/components/SearchPanel.js
@@ -47,6 +47,7 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
     searchType: 'both',
     searchIn: 'both',
     caseSensitive: false,
+    trimQuery: true,
     extension: '',
     sizeRange: undefined,
     dateRange: undefined,
@@ -151,13 +152,21 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
         onClearSearch();
       }
       const searchValues = await searchForm.validateFields(['query']);
-      
+
+      const rawQuery = searchValues.query || '';
+      const shouldTrimQuery = searchSettings.trimQuery !== false;
+      const normalizedQuery = shouldTrimQuery ? rawQuery.trim() : rawQuery;
+
+      if (shouldTrimQuery && rawQuery !== normalizedQuery) {
+        searchForm.setFieldsValue({ query: normalizedQuery });
+      }
+
       const limitEnabled = searchSettings.limitEnabled !== false;
       const limitValueRaw = Number(searchSettings.limit);
       const limitValue = Number.isFinite(limitValueRaw) && limitValueRaw > 0 ? limitValueRaw : 100;
 
       const searchParams = {
-        query: searchValues.query || '',
+        query: normalizedQuery,
         mode: searchSettings.mode || 'contains',
         caseSensitive: searchSettings.caseSensitive ? 'true' : 'false',
         searchType: searchSettings.searchType || 'both',
@@ -274,7 +283,8 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
         limitEnabled: values.limitEnabled !== false,
         limit: Number.isFinite(limitFromForm) && limitFromForm > 0
           ? limitFromForm
-          : existingLimit
+          : existingLimit,
+        trimQuery: values.trimQuery !== false
       };
       setSearchSettings(normalizedValues);
       settingsForm.setFieldsValue(normalizedValues);
@@ -410,6 +420,19 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
                   <Option value="folders">Folders Only</Option>
                   <Option value="files">Files Only</Option>
                 </Select>
+              </Form.Item>
+            </Col>
+
+            <Col span={8}>
+              <Form.Item
+                label="Trim Query Spaces"
+                name="trimQuery"
+                valuePropName="checked"
+              >
+                <Switch
+                  checkedChildren="Trim"
+                  unCheckedChildren="Keep"
+                />
               </Form.Item>
             </Col>
           </Row>

--- a/client/src/components/SearchPanel.js
+++ b/client/src/components/SearchPanel.js
@@ -154,14 +154,14 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
       const searchValues = await searchForm.validateFields(['query']);
 
       const rawQuery = searchValues.query || '';
-      const shouldTrimQuery = searchSettings.trimQuery !== false;
+      const shouldTrimQuery = searchSettings.trimQuery ?? true;
       const normalizedQuery = shouldTrimQuery ? rawQuery.trim() : rawQuery;
 
       if (shouldTrimQuery && rawQuery !== normalizedQuery) {
         searchForm.setFieldsValue({ query: normalizedQuery });
       }
 
-      const limitEnabled = searchSettings.limitEnabled !== false;
+      const limitEnabled = searchSettings.limitEnabled ?? true;
       const limitValueRaw = Number(searchSettings.limit);
       const limitValue = Number.isFinite(limitValueRaw) && limitValueRaw > 0 ? limitValueRaw : 100;
 
@@ -280,11 +280,11 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
         : 100;
       const normalizedValues = {
         ...values,
-        limitEnabled: values.limitEnabled !== false,
+        limitEnabled: values.limitEnabled ?? true,
         limit: Number.isFinite(limitFromForm) && limitFromForm > 0
           ? limitFromForm
           : existingLimit,
-        trimQuery: values.trimQuery !== false
+        trimQuery: values.trimQuery ?? true
       };
       setSearchSettings(normalizedValues);
       settingsForm.setFieldsValue(normalizedValues);
@@ -494,7 +494,8 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
                 shouldUpdate={(prev, curr) => prev.limitEnabled !== curr.limitEnabled}
               >
                 {({ getFieldValue }) => {
-                  const limitEnabledValue = getFieldValue('limitEnabled') !== false;
+                  const limitEnabledValue = getFieldValue('limitEnabled');
+                  const limitEnabledChecked = limitEnabledValue ?? true;
                   return (
                     <Space align="center">
                       <Form.Item name="limitEnabled" valuePropName="checked" noStyle>
@@ -503,7 +504,7 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
                       <Form.Item
                         name="limit"
                         noStyle
-                        rules={limitEnabledValue ? [
+                        rules={limitEnabledChecked ? [
                           { required: true, message: 'Please enter a result limit' },
                           { type: 'number', min: 1, message: 'Limit must be at least 1' }
                         ] : []}
@@ -512,7 +513,7 @@ const SearchPanel = ({ onSearch, onScan, onClearSearch, loading, hasResults }) =
                           min={1}
                           step={1}
                           precision={0}
-                          disabled={!limitEnabledValue}
+                          disabled={!limitEnabledChecked}
                           style={{ width: 140 }}
                         />
                       </Form.Item>


### PR DESCRIPTION
## Summary
- add a persistent "Trim Query Spaces" toggle to the search settings modal
- default the setting to enabled and trim the search term automatically when active
- ensure the query field reflects the trimmed value when trimming is on

## Testing
- `npm run build` *(fails: react-scripts not found before dependencies were installed)*
- `npm install` *(fails: 403 Forbidden when fetching typescript from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b55450708332a335bd845c57645e